### PR TITLE
Update data_preprocessing.ipynb

### DIFF
--- a/data_preprocessing.ipynb
+++ b/data_preprocessing.ipynb
@@ -44,8 +44,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def bin_spikes( S, bin_size ):\n",
+    "def bin_spikes( S, bin_size, trial_time ):\n",
     "    # Ryan\n",
+    "    P = list()\n",
+    "    t_bin = np.arange(trial_time, step = bin_size)\n",
+    "    for s_trial in S:\n",
+    "        pi = list()\n",
+    "        for unit in s_trial:\n",
+    "            pj, _ = np.histogram(np.array(unit), bins = t_bin)\n",
+    "            pi.append(pj)\n",
+    "        P.append(pi)\n",
     "    return (t_bin, P)"
    ]
   },


### PR DESCRIPTION
Spikes in each time bin calculated. Returns array of time bins and list of list of np-arrays [#trialstrial_time/bin_size]. I am assuming that all trials and units being fed into this function have the same trial length.